### PR TITLE
refactor type traits, fix other warnings

### DIFF
--- a/src/stk/cuda/ptr.h
+++ b/src/stk/cuda/ptr.h
@@ -16,7 +16,7 @@ namespace stk
                 pitch(vol.pitched_ptr().pitch),
                 ysize(vol.pitched_ptr().ysize)
             {
-                ASSERT(vol.voxel_type() == type_id<T>::id);
+                ASSERT(vol.voxel_type() == type_id<T>::id());
                 ASSERT(vol.usage() == gpu::Usage_PitchedPointer);
             }
 

--- a/src/stk/image/types.h
+++ b/src/stk/image/types.h
@@ -54,7 +54,7 @@ namespace stk
         Type_Double3,
         Type_Double4
     };
-    
+
     // Returns the total size in bytes of the specified type
     size_t type_size(Type type);
 
@@ -76,12 +76,8 @@ namespace stk
     struct type_id
     {
         typedef T Type;
-        enum {
-            id = Type_Unknown
-        };
+        static constexpr stk::Type id(void) {return Type_Unknown;};
     };
-
-    // TODO: Annoying thing: you'll have to explicitly typecast type_id<>::id into Type
 
     #define TYPE_ID(T, BT, Id, NumComp) \
         template<> \
@@ -89,10 +85,8 @@ namespace stk
         { \
             typedef T Type; \
             typedef BT Base; \
-            enum { \
-                id = Id, \
-                num_comp = NumComp \
-            }; \
+            static constexpr stk::Type id(void) {return Id;}; \
+            static constexpr int num_comp(void) {return NumComp;}; \
         };
 
     TYPE_ID(char, char, Type_Char, 1);
@@ -137,4 +131,3 @@ namespace stk
 
     #undef TYPE_ID
 }
-

--- a/src/stk/image/volume.inl
+++ b/src/stk/image/volume.inl
@@ -3,7 +3,7 @@ namespace stk
 template<typename T>
 VolumeHelper<T>::VolumeHelper()
 {
-    _voxel_type = (Type)type_id<T>::id;
+    _voxel_type = type_id<T>::id();
 }
 template<typename T>
 VolumeHelper<T>::VolumeHelper(const Volume& other) : Volume()
@@ -11,18 +11,18 @@ VolumeHelper<T>::VolumeHelper(const Volume& other) : Volume()
     *this = other; // Operator performs conversion (if needed)
 }
 template<typename T>
-VolumeHelper<T>::VolumeHelper(const dim3& size) : Volume(size, (Type)type_id<T>::id)
+VolumeHelper<T>::VolumeHelper(const dim3& size) : Volume(size, type_id<T>::id())
 {
 }
 template<typename T>
-VolumeHelper<T>::VolumeHelper(const dim3& size, const T& value) : 
-    Volume(size, (Type)type_id<T>::id)
+VolumeHelper<T>::VolumeHelper(const dim3& size, const T& value) :
+    Volume(size, type_id<T>::id())
 {
     fill(value);
 }
 template<typename T>
-VolumeHelper<T>::VolumeHelper(const dim3& size, T* value) : 
-    Volume(size, (Type)type_id<T>::id, value)
+VolumeHelper<T>::VolumeHelper(const dim3& size, T* value) :
+    Volume(size, type_id<T>::id(), value)
 {
 }
 template<typename T>
@@ -32,7 +32,7 @@ VolumeHelper<T>::~VolumeHelper()
 template<typename T>
 void VolumeHelper<T>::allocate(const dim3& size)
 {
-    Volume::allocate(size, (Type)type_id<T>::id);
+    Volume::allocate(size, type_id<T>::id());
 }
 template<typename T>
 void VolumeHelper<T>::fill(const T& value)
@@ -52,11 +52,11 @@ T VolumeHelper<T>::at(int x, int y, int z, BorderMode border_mode) const
     #define FAST_CEIL(x_) ((int)x_ + (x_ > (int)x_))
     #define FAST_FLOOR(x_) ((int)x_ - (x_ < (int)x_))
 
-    if (border_mode == Border_Constant) 
+    if (border_mode == Border_Constant)
     {
         if (x < 0 || FAST_CEIL(x) >= int(_size.x) ||
             y < 0 || FAST_CEIL(y) >= int(_size.y) ||
-            z < 0 || FAST_CEIL(z) >= int(_size.z)) 
+            z < 0 || FAST_CEIL(z) >= int(_size.z))
         {
             return T{0};
         }
@@ -90,11 +90,11 @@ inline T VolumeHelper<T>::linear_at(float x, float y, float z, BorderMode border
     // We expect all indices to be positive therefore a regular cast should suffice
     #define FAST_FLOOR(x_) int(x_)
 
-    if (border_mode == Border_Constant) 
+    if (border_mode == Border_Constant)
     {
         if (x < 0 || FAST_CEIL(x) >= int(_size.x) ||
             y < 0 || FAST_CEIL(y) >= int(_size.y) ||
-            z < 0 || FAST_CEIL(z) >= int(_size.z)) 
+            z < 0 || FAST_CEIL(z) >= int(_size.z))
         {
             return T{0};
         }
@@ -129,20 +129,20 @@ inline T VolumeHelper<T>::linear_at(float x, float y, float z, BorderMode border
                     (xt) * operator()(x2, y1, z1) // s2
                 ) +
 
-                (yt) * 
+                (yt) *
                 (
                     (1 - xt) * operator()(x1, y2, z1) + // s3
                     (xt) * operator()(x2, y2, z1) // s4
                 )
             ) +
-        (zt) * 
+        (zt) *
             (
                 (1 - yt)*
                 (
                     (1 - xt)*operator()(x1, y1, z2) + // s5
                     (xt)*operator()(x2, y1, z2) // s6
                 ) +
-                
+
                 (yt)*
                 (
                     (1 - xt)*operator()(x1, y2, z2) + // s7
@@ -166,11 +166,11 @@ inline float VolumeHelper<float>::linear_at(float x, float y, float z, BorderMod
     #define FAST_CEIL(x_) ((int)x_ + (x_ > (int)x_))
     #define FAST_FLOOR(x_) int(x_)
 
-    if (border_mode == volume::Border_Constant) 
+    if (border_mode == volume::Border_Constant)
     {
         if (x < 0 || FAST_CEIL(x) >= int(_size.x) ||
             y < 0 || FAST_CEIL(y) >= int(_size.y) ||
-            z < 0 || FAST_CEIL(z) >= int(_size.z)) 
+            z < 0 || FAST_CEIL(z) >= int(_size.z))
         {
             return 0;
         }
@@ -296,14 +296,14 @@ T VolumeHelper<T>::linear_at(float3 p, BorderMode border_mode) const
 template<typename T>
 VolumeHelper<T>& VolumeHelper<T>::operator=(const VolumeHelper& other)
 {
-    ASSERT(type_id<T>::id == other.voxel_type()); // Sanity check
+    ASSERT(type_id<T>::id() == other.voxel_type()); // Sanity check
     Volume::operator=(other);
     return *this;
 }
 template<typename T>
 VolumeHelper<T>& VolumeHelper<T>::operator=(const Volume& other)
 {
-    if (static_cast<enum stk::Type>(type_id<T>::id) == other.voxel_type()) {
+    if (static_cast<enum stk::Type>(type_id<T>::id()) == other.voxel_type()) {
         Volume::operator=(other);
         return *this;
     }
@@ -312,7 +312,7 @@ VolumeHelper<T>& VolumeHelper<T>::operator=(const Volume& other)
         return *this;
     }
 
-    *this = other.as_type((Type)type_id<T>::id);
+    *this = other.as_type(type_id<T>::id());
     return *this;
 }
 

--- a/test/test_types.cpp
+++ b/test/test_types.cpp
@@ -29,15 +29,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_Char3) == Type_Char);
         REQUIRE(base_type(Type_Char4) == Type_Char);
 
-        REQUIRE(type_id<char>::id == Type_Char);
-        REQUIRE(type_id<char2>::id == Type_Char2);
-        REQUIRE(type_id<char3>::id == Type_Char3);
-        REQUIRE(type_id<char4>::id == Type_Char4);
+        REQUIRE(type_id<char>::id() == Type_Char);
+        REQUIRE(type_id<char2>::id() == Type_Char2);
+        REQUIRE(type_id<char3>::id() == Type_Char3);
+        REQUIRE(type_id<char4>::id() == Type_Char4);
 
-        REQUIRE(type_id<char>::num_comp == 1);
-        REQUIRE(type_id<char2>::num_comp == 2);
-        REQUIRE(type_id<char3>::num_comp == 3);
-        REQUIRE(type_id<char4>::num_comp == 4);
+        REQUIRE(type_id<char>::num_comp() == 1);
+        REQUIRE(type_id<char2>::num_comp() == 2);
+        REQUIRE(type_id<char3>::num_comp() == 3);
+        REQUIRE(type_id<char4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_Char), Equals("char"));
         REQUIRE_THAT(as_string(Type_Char2), Equals("char2"));
@@ -61,15 +61,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_UChar3) == Type_UChar);
         REQUIRE(base_type(Type_UChar4) == Type_UChar);
 
-        REQUIRE(type_id<uint8_t>::id == Type_UChar);
-        REQUIRE(type_id<uchar2>::id == Type_UChar2);
-        REQUIRE(type_id<uchar3>::id == Type_UChar3);
-        REQUIRE(type_id<uchar4>::id == Type_UChar4);
+        REQUIRE(type_id<uint8_t>::id() == Type_UChar);
+        REQUIRE(type_id<uchar2>::id() == Type_UChar2);
+        REQUIRE(type_id<uchar3>::id() == Type_UChar3);
+        REQUIRE(type_id<uchar4>::id() == Type_UChar4);
 
-        REQUIRE(type_id<uint8_t>::num_comp == 1);
-        REQUIRE(type_id<uchar2>::num_comp == 2);
-        REQUIRE(type_id<uchar3>::num_comp == 3);
-        REQUIRE(type_id<uchar4>::num_comp == 4);
+        REQUIRE(type_id<uint8_t>::num_comp() == 1);
+        REQUIRE(type_id<uchar2>::num_comp() == 2);
+        REQUIRE(type_id<uchar3>::num_comp() == 3);
+        REQUIRE(type_id<uchar4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_UChar), Equals("uchar"));
         REQUIRE_THAT(as_string(Type_UChar2), Equals("uchar2"));
@@ -93,15 +93,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_Short3) == Type_Short);
         REQUIRE(base_type(Type_Short4) == Type_Short);
 
-        REQUIRE(type_id<short>::id == Type_Short);
-        REQUIRE(type_id<short2>::id == Type_Short2);
-        REQUIRE(type_id<short3>::id == Type_Short3);
-        REQUIRE(type_id<short4>::id == Type_Short4);
+        REQUIRE(type_id<short>::id() == Type_Short);
+        REQUIRE(type_id<short2>::id() == Type_Short2);
+        REQUIRE(type_id<short3>::id() == Type_Short3);
+        REQUIRE(type_id<short4>::id() == Type_Short4);
 
-        REQUIRE(type_id<short>::num_comp == 1);
-        REQUIRE(type_id<short2>::num_comp == 2);
-        REQUIRE(type_id<short3>::num_comp == 3);
-        REQUIRE(type_id<short4>::num_comp == 4);
+        REQUIRE(type_id<short>::num_comp() == 1);
+        REQUIRE(type_id<short2>::num_comp() == 2);
+        REQUIRE(type_id<short3>::num_comp() == 3);
+        REQUIRE(type_id<short4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_Short), Equals("short"));
         REQUIRE_THAT(as_string(Type_Short2), Equals("short2"));
@@ -125,15 +125,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_UShort3) == Type_UShort);
         REQUIRE(base_type(Type_UShort4) == Type_UShort);
 
-        REQUIRE(type_id<uint16_t>::id == Type_UShort);
-        REQUIRE(type_id<ushort2>::id == Type_UShort2);
-        REQUIRE(type_id<ushort3>::id == Type_UShort3);
-        REQUIRE(type_id<ushort4>::id == Type_UShort4);
+        REQUIRE(type_id<uint16_t>::id() == Type_UShort);
+        REQUIRE(type_id<ushort2>::id() == Type_UShort2);
+        REQUIRE(type_id<ushort3>::id() == Type_UShort3);
+        REQUIRE(type_id<ushort4>::id() == Type_UShort4);
 
-        REQUIRE(type_id<uint16_t>::num_comp == 1);
-        REQUIRE(type_id<ushort2>::num_comp == 2);
-        REQUIRE(type_id<ushort3>::num_comp == 3);
-        REQUIRE(type_id<ushort4>::num_comp == 4);
+        REQUIRE(type_id<uint16_t>::num_comp() == 1);
+        REQUIRE(type_id<ushort2>::num_comp() == 2);
+        REQUIRE(type_id<ushort3>::num_comp() == 3);
+        REQUIRE(type_id<ushort4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_UShort), Equals("ushort"));
         REQUIRE_THAT(as_string(Type_UShort2), Equals("ushort2"));
@@ -157,15 +157,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_Int3) == Type_Int);
         REQUIRE(base_type(Type_Int4) == Type_Int);
 
-        REQUIRE(type_id<int>::id == Type_Int);
-        REQUIRE(type_id<int2>::id == Type_Int2);
-        REQUIRE(type_id<int3>::id == Type_Int3);
-        REQUIRE(type_id<int4>::id == Type_Int4);
+        REQUIRE(type_id<int>::id() == Type_Int);
+        REQUIRE(type_id<int2>::id() == Type_Int2);
+        REQUIRE(type_id<int3>::id() == Type_Int3);
+        REQUIRE(type_id<int4>::id() == Type_Int4);
 
-        REQUIRE(type_id<int>::num_comp == 1);
-        REQUIRE(type_id<int2>::num_comp == 2);
-        REQUIRE(type_id<int3>::num_comp == 3);
-        REQUIRE(type_id<int4>::num_comp == 4);
+        REQUIRE(type_id<int>::num_comp() == 1);
+        REQUIRE(type_id<int2>::num_comp() == 2);
+        REQUIRE(type_id<int3>::num_comp() == 3);
+        REQUIRE(type_id<int4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_Int), Equals("int"));
         REQUIRE_THAT(as_string(Type_Int2), Equals("int2"));
@@ -189,15 +189,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_UInt3) == Type_UInt);
         REQUIRE(base_type(Type_UInt4) == Type_UInt);
 
-        REQUIRE(type_id<uint32_t>::id == Type_UInt);
-        REQUIRE(type_id<uint2>::id == Type_UInt2);
-        REQUIRE(type_id<uint3>::id == Type_UInt3);
-        REQUIRE(type_id<uint4>::id == Type_UInt4);
+        REQUIRE(type_id<uint32_t>::id() == Type_UInt);
+        REQUIRE(type_id<uint2>::id() == Type_UInt2);
+        REQUIRE(type_id<uint3>::id() == Type_UInt3);
+        REQUIRE(type_id<uint4>::id() == Type_UInt4);
 
-        REQUIRE(type_id<uint32_t>::num_comp == 1);
-        REQUIRE(type_id<uint2>::num_comp == 2);
-        REQUIRE(type_id<uint3>::num_comp == 3);
-        REQUIRE(type_id<uint4>::num_comp == 4);
+        REQUIRE(type_id<uint32_t>::num_comp() == 1);
+        REQUIRE(type_id<uint2>::num_comp() == 2);
+        REQUIRE(type_id<uint3>::num_comp() == 3);
+        REQUIRE(type_id<uint4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_UInt), Equals("uint"));
         REQUIRE_THAT(as_string(Type_UInt2), Equals("uint2"));
@@ -221,15 +221,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_Float3) == Type_Float);
         REQUIRE(base_type(Type_Float4) == Type_Float);
             
-        REQUIRE(type_id<float>::id == Type_Float);
-        REQUIRE(type_id<float2>::id == Type_Float2);
-        REQUIRE(type_id<float3>::id == Type_Float3);
-        REQUIRE(type_id<float4>::id == Type_Float4);
+        REQUIRE(type_id<float>::id() == Type_Float);
+        REQUIRE(type_id<float2>::id() == Type_Float2);
+        REQUIRE(type_id<float3>::id() == Type_Float3);
+        REQUIRE(type_id<float4>::id() == Type_Float4);
 
-        REQUIRE(type_id<float>::num_comp == 1);
-        REQUIRE(type_id<float2>::num_comp == 2);
-        REQUIRE(type_id<float3>::num_comp == 3);
-        REQUIRE(type_id<float4>::num_comp == 4);
+        REQUIRE(type_id<float>::num_comp() == 1);
+        REQUIRE(type_id<float2>::num_comp() == 2);
+        REQUIRE(type_id<float3>::num_comp() == 3);
+        REQUIRE(type_id<float4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_Float), Equals("float"));
         REQUIRE_THAT(as_string(Type_Float2), Equals("float2"));
@@ -253,15 +253,15 @@ TEST_CASE("types", "[volume]")
         REQUIRE(base_type(Type_Double3) == Type_Double);
         REQUIRE(base_type(Type_Double4) == Type_Double);
             
-        REQUIRE(type_id<double>::id == Type_Double);
-        REQUIRE(type_id<double2>::id == Type_Double2);
-        REQUIRE(type_id<double3>::id == Type_Double3);
-        REQUIRE(type_id<double4>::id == Type_Double4);
+        REQUIRE(type_id<double>::id() == Type_Double);
+        REQUIRE(type_id<double2>::id() == Type_Double2);
+        REQUIRE(type_id<double3>::id() == Type_Double3);
+        REQUIRE(type_id<double4>::id() == Type_Double4);
 
-        REQUIRE(type_id<double>::num_comp == 1);
-        REQUIRE(type_id<double2>::num_comp == 2);
-        REQUIRE(type_id<double3>::num_comp == 3);
-        REQUIRE(type_id<double4>::num_comp == 4);
+        REQUIRE(type_id<double>::num_comp() == 1);
+        REQUIRE(type_id<double2>::num_comp() == 2);
+        REQUIRE(type_id<double3>::num_comp() == 3);
+        REQUIRE(type_id<double4>::num_comp() == 4);
 
         REQUIRE_THAT(as_string(Type_Double), Equals("double"));
         REQUIRE_THAT(as_string(Type_Double2), Equals("double2"));

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -63,7 +63,7 @@ bool compare_volumes(const stk::VolumeHelper<T>& a, const stk::VolumeHelper<T>& 
     return true;
 }
 
-template<typename T, typename BT = typename stk::type_id<T>::Base, int NC=stk::type_id<T>::num_comp>
+template<typename T, typename BT = typename stk::type_id<T>::Base, int NC=stk::type_id<T>::num_comp()>
 struct TestDataGenerator
 {
     static void run(T* out, int w, int h, int d)

--- a/test/test_volume.cpp
+++ b/test/test_volume.cpp
@@ -77,7 +77,7 @@ TEST_CASE("volume_ref", "[volume]")
     // Test reference handling
 
     uint8_t test_data[W*H*D];
-    for (int i = 0; i < W*H*D; ++i)
+    for (uint32_t i = 0; i < W*H*D; ++i)
         test_data[i] = uint8_t(i);
 
     SECTION("assignment")
@@ -95,7 +95,7 @@ TEST_CASE("volume_ref", "[volume]")
         REQUIRE(!vol.valid());
         REQUIRE(copy.valid());
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<uint8_t*>(copy.ptr())[i] == test_data[i]);
         }
     }
@@ -114,7 +114,7 @@ TEST_CASE("volume_ref", "[volume]")
         REQUIRE(!vol.valid());
         REQUIRE(copy.valid());
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<uint8_t*>(copy.ptr())[i] == test_data[i]);
         }
     }
@@ -126,7 +126,7 @@ TEST_CASE("volume_types", "[volume]")
         SECTION(#T) \
         { \
             T test_data[W*H*D]; \
-            for (int i = 0; i < W*H*D; ++i) { \
+            for (uint32_t i = 0; i < W*H*D; ++i) { \
                 test_data[i] = T{0}; \
             } \
             Volume vol({W,H,D}, T_id, test_data); \
@@ -176,7 +176,7 @@ TEST_CASE("volume_meta_data", "[volume]")
 TEST_CASE("volume_clone", "[volume]")
 {
     float test_data[W*H*D];
-    for (int i = 0; i < W*H*D; ++i)
+    for (uint32_t i = 0; i < W*H*D; ++i)
         test_data[i] = float(i);
 
     Volume vol({W,H,D}, Type_Float, test_data);
@@ -199,7 +199,7 @@ TEST_CASE("volume_clone", "[volume]")
             
     REQUIRE(clone.ptr() != vol.ptr()); // Should not point to the same memory
 
-    for (int i = 0; i < W*H*D; ++i) {
+    for (uint32_t i = 0; i < W*H*D; ++i) {
         REQUIRE(static_cast<float*>(clone.ptr())[i] == Approx(test_data[i]));
     }
 
@@ -211,7 +211,7 @@ TEST_CASE("volume_clone", "[volume]")
 TEST_CASE("volume_copy_from", "[volume]")
 {
     float test_data[W*H*D];
-    for (int i = 0; i < W*H*D; ++i)
+    for (uint32_t i = 0; i < W*H*D; ++i)
         test_data[i] = float(i);
 
     Volume vol({W,H,D}, Type_Float, test_data);
@@ -231,7 +231,7 @@ TEST_CASE("volume_copy_from", "[volume]")
     REQUIRE(copy.spacing().y == Approx(vol.spacing().y));
     REQUIRE(copy.spacing().z == Approx(vol.spacing().z));
 
-    for (int i = 0; i < W*H*D; ++i) {
+    for (uint32_t i = 0; i < W*H*D; ++i) {
         REQUIRE(static_cast<float*>(copy.ptr())[i] == Approx(test_data[i]));
     }
 }
@@ -241,7 +241,7 @@ TEST_CASE("volume_as_type", "[volume]")
     SECTION("float_to_double")
     {
         float test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = float(i);
 
         Volume vol({W,H,D}, Type_Float, test_data);
@@ -261,14 +261,14 @@ TEST_CASE("volume_as_type", "[volume]")
         REQUIRE(vol2.spacing().y == Approx(vol.spacing().y));
         REQUIRE(vol2.spacing().z == Approx(vol.spacing().z));
         
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<double*>(vol2.ptr())[i] == Approx(test_data[i]));
         }
     }
     SECTION("double_to_float")
     {
         double test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = double(i);
 
         Volume vol({W,H,D}, Type_Double, test_data);
@@ -278,14 +278,14 @@ TEST_CASE("volume_as_type", "[volume]")
         REQUIRE(vol2.voxel_type() == Type_Float);
         REQUIRE(vol2.ptr() != vol.ptr());
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<float*>(vol2.ptr())[i] == Approx(test_data[i]));
         }
     }
     SECTION("double4_to_float4")
     {
         double4 test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = double4{double(i), double(i+1), double(i+2), double(i+3)};
 
         Volume vol({W,H,D}, Type_Double4, test_data);
@@ -295,7 +295,7 @@ TEST_CASE("volume_as_type", "[volume]")
         REQUIRE(vol2.voxel_type() == Type_Float4);
         REQUIRE(vol2.ptr() != vol.ptr());
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             float4 s = static_cast<float4*>(vol2.ptr())[i];
             double4 t = test_data[i];
             REQUIRE(s.x == Approx(t.x));
@@ -307,7 +307,7 @@ TEST_CASE("volume_as_type", "[volume]")
     SECTION("float_to_float")
     {
         float test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = float(i);
 
         Volume vol({W,H,D}, Type_Float, test_data);
@@ -321,7 +321,7 @@ TEST_CASE("volume_as_type", "[volume]")
     SECTION("float_to_float2")
     {
         float test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = float(i);
 
         Volume vol({W,H,D}, Type_Float, test_data);
@@ -332,7 +332,7 @@ TEST_CASE("volume_as_type", "[volume]")
     SECTION("float_to_uchar")
     {
         float test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = float(i);
 
         Volume vol({W,H,D}, Type_Float, test_data);
@@ -356,7 +356,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(vol.valid());
         REQUIRE(vol.voxel_type() == Type_Float);
         
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             static_cast<float*>(vol.ptr())[i] = float(i);
         }
     }
@@ -366,7 +366,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(vol.valid());
         REQUIRE(vol.voxel_type() == Type_Float);
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<float*>(vol.ptr())[i] == Approx(3.0f));
         }
     }
@@ -375,7 +375,7 @@ TEST_CASE("volume_helper", "[volume]")
     SECTION("copy_constructor")
     {
         float test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = float(i);
 
         Volume src({W,H,D}, Type_Float, test_data);
@@ -386,7 +386,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(copy1.voxel_type() == Type_Float);
         REQUIRE(copy1.size() == dim3{W,H,D});
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<float*>(copy1.ptr())[i] == Approx(test_data[i]));
         }
 
@@ -396,7 +396,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(copy2.voxel_type() == Type_Double);
         REQUIRE(copy2.size() == dim3{W,H,D});
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<double*>(copy2.ptr())[i] == Approx(test_data[i]));
         }
 
@@ -407,7 +407,7 @@ TEST_CASE("volume_helper", "[volume]")
     SECTION("copy_assignment")
     {
         double4 test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = double4{double(i), double(i+1), double(i+2), double(i+3)};
 
         Volume src({W,H,D}, Type_Double4, test_data);
@@ -418,7 +418,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(copy1.voxel_type() == Type_Double4);
         REQUIRE(copy1.size() == dim3{W,H,D});
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             double4 s = static_cast<double4*>(copy1.ptr())[i];
             double4 t = test_data[i];
             REQUIRE(s.x == Approx(t.x));
@@ -433,7 +433,7 @@ TEST_CASE("volume_helper", "[volume]")
         REQUIRE(copy2.voxel_type() == Type_Float4);
         REQUIRE(copy2.size() == dim3{W,H,D});
 
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             float4 s = static_cast<float4*>(copy2.ptr())[i];
             double4 t = test_data[i];
             REQUIRE(s.x == Approx(t.x));
@@ -449,13 +449,13 @@ TEST_CASE("volume_helper", "[volume]")
     SECTION("indexing")
     {
         uchar3 test_data[W*H*D];
-        for (int i = 0; i < W*H*D; ++i)
+        for (uint32_t i = 0; i < W*H*D; ++i)
             test_data[i] = uchar3{uint8_t(i), uint8_t(i+1), uint8_t(i+2)};
 
         VolumeHelper<uchar3> vol({W,H,D}, test_data);
-        for (int z = 0; z < D; ++z) {
-            for (int y = 0; y < H; ++y) {
-                for (int x = 0; x < W; ++x) {
+        for (uint32_t z = 0; z < D; ++z) {
+            for (uint32_t y = 0; y < H; ++y) {
+                for (uint32_t x = 0; x < W; ++x) {
                     uchar3 s = vol(x,y,z);
                     uchar3 t = test_data[x + y * W + z * W * H];
                     REQUIRE(s.x == t.x);
@@ -478,7 +478,7 @@ TEST_CASE("volume_helper", "[volume]")
     {
         VolumeHelper<float> vol({W,H,D});
         vol.fill(5.5f);
-        for (int i = 0; i < W*H*D; ++i) {
+        for (uint32_t i = 0; i < W*H*D; ++i) {
             REQUIRE(static_cast<float*>(vol.ptr())[i] == Approx(5.5f));
         }
     }


### PR DESCRIPTION
Tried to refactor the type traits using static methods instead of anonymous unions, this should solve the problem of casting between unions.

Fixed some other implicit cast-related warnings.

I did not merge this myself because it is an API-breaker change, so better if you review it first.