### PR TITLE
Sub volume

### DIFF
--- a/src/stk/image/gpu_volume.cpp
+++ b/src/stk/image/gpu_volume.cpp
@@ -118,6 +118,65 @@ namespace
 
         return vol;
     }
+
+    cudaMemcpy3DParms make_download_params(const GpuVolume& src, const Volume& dst)
+    {
+        cudaMemcpy3DParms params = {0};
+
+        // We also assume both volumes have same dimensions
+        ASSERT(dst.size() == src.size());
+        ASSERT(dst.voxel_type() == src.voxel_type());
+
+        dim3 size = dst.size();
+
+        params.kind = cudaMemcpyDeviceToHost;
+        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(dst.ptr()),
+            dst.strides()[1], dst.strides()[1]/dst.strides()[0], dst.strides()[2]/dst.strides()[1]);
+
+        // Extent width is defined in terms of elements if any cudaArray is present,
+        //  otherwise in number of bytes (for pitched pointer)
+        size_t per_voxel = 1;
+        if (src.usage() == gpu::Usage_PitchedPointer) {
+            params.srcPtr = src.pitched_ptr();
+            per_voxel = type_size(src.voxel_type());
+        }
+        else {
+            params.srcArray = src.array_ptr();
+            per_voxel = 1;
+        }
+
+        params.extent = make_cudaExtent(size.x * per_voxel, size.y, size.z);
+        return params;
+    }
+
+    cudaMemcpy3DParms make_upload_params(const Volume& src, const GpuVolume& dst)
+    {
+        cudaMemcpy3DParms params = {0};
+
+        // We also assume both volumes have same dimensions
+        ASSERT(src.size() == dst.size());
+        ASSERT(src.voxel_type() == dst.voxel_type());
+
+        dim3 size = src.size();
+
+        params.kind = cudaMemcpyHostToDevice;
+        params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(src.ptr()),
+            src.strides()[1], src.strides()[1]/src.strides()[0], src.strides()[2]/src.strides()[1]);
+
+        // Extent width is defined in terms of elements if any cudaArray is present,
+        //  otherwise in number of bytes (for pitched pointer)
+        size_t per_voxel = 1;
+        if (dst.usage() == gpu::Usage_PitchedPointer) {
+            params.dstPtr = dst.pitched_ptr();
+            per_voxel = type_size(dst.voxel_type());
+        }
+        else {
+            params.dstArray = dst.array_ptr();
+            per_voxel = 1;
+        }
+        params.extent = make_cudaExtent(size.x * per_voxel, size.y, size.z);
+        return params;
+    }
 }
 
 namespace stk
@@ -198,18 +257,74 @@ GpuVolumeData::~GpuVolumeData()
     }
 }
 
-GpuVolume::GpuVolume()
+GpuVolume::GpuVolume() :
+    _size{0,0,0},
+    _origin{0,0,0},
+    _spacing{1,1,1},
+    _ptr{0}
 {
-    _size = {0};
-    _origin = {0, 0, 0};
-    _spacing = {1, 1, 1};
 }
-GpuVolume::GpuVolume(const dim3& size, Type voxel_type, gpu::Usage usage)
+GpuVolume::GpuVolume(const GpuVolume& other) :
+    _data(other._data),
+    _size(other._size),
+    _origin(other._origin),
+    _spacing(other._spacing),
+    _ptr(other._ptr)
 {
-    _size = size;
-    _origin = {0, 0, 0};
-    _spacing = {1, 1, 1};
-    _data = allocate_gpu_volume(size, voxel_type, usage);
+}
+GpuVolume& GpuVolume::operator=(const GpuVolume& other)
+{
+    if (this != &other) {
+        _data = other._data;
+        _size = other._size;
+        _origin = other._origin;
+        _spacing = other._spacing;
+        _ptr = other._ptr;
+    }
+    return *this;
+}
+GpuVolume::GpuVolume(const dim3& size, Type voxel_type, gpu::Usage usage) :
+    _origin({0,0,0}),
+    _spacing({1,1,1}),
+    _ptr({0})
+{
+    allocate(size, voxel_type, usage);
+}
+GpuVolume::GpuVolume(const GpuVolume& other, const Range& x, const Range& y, const Range& z) :
+    _data(other._data),
+    _origin(other._origin),
+    _spacing(other._spacing),
+    _ptr(other._ptr)
+{
+    // Subvolumes are only supported for pitched pointer types
+    ASSERT(other.usage() == gpu::Usage_PitchedPointer);
+    ASSERT(other.valid());
+    ASSERT(x.begin <= x.end && y.begin <= y.end && z.begin <= z.end);
+    ASSERT(0 <= x.begin && x.end <= (int)other._size.x);
+    ASSERT(0 <= y.begin && y.end <= (int)other._size.y);
+    ASSERT(0 <= z.begin && z.end <= (int)other._size.z);
+
+    int nx = x.end - x.begin;
+    int ny = y.end - y.begin;
+    int nz = z.end - z.begin;
+
+    uint8_t* ptr = reinterpret_cast<uint8_t*>(_ptr.ptr);
+    
+    if (z.begin != 0 && z.end != (int)_size.z) {
+        // any offset in z axis does not break contiguity 
+        ptr += z.begin * _ptr.pitch * _ptr.ysize;
+    }
+
+    if (y.begin != 0 && y.end != (int)_size.y) {
+        ptr += y.begin * _ptr.pitch;
+    }
+
+    if (x.begin != 0 && x.end != (int)_size.x) {
+        ptr += x.begin * type_size(voxel_type());
+    }
+
+    _size = dim3{(uint32_t)nx, (uint32_t)ny, (uint32_t)nz};
+    _ptr = make_cudaPitchedPtr(ptr, _ptr.pitch, _ptr.xsize, _ptr.ysize);
 }
 GpuVolume::~GpuVolume()
 {
@@ -392,36 +507,7 @@ void GpuVolume::download(Volume& vol) const
     ASSERT(valid()); // Requires gpu memory to be allocated
     ASSERT(vol.valid()); // Requires cpu memory to be allocated as well
 
-    // We also assume both volumes have same dimensions
-    ASSERT(vol.size() == _size);
-    ASSERT(vol.voxel_type() == voxel_type());
-
-    cudaMemcpy3DParms params = {0};
-    params.kind = cudaMemcpyDeviceToHost;
-    if (vol.is_contiguous()) {
-        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, _size.y);
-    } else {
-        // For non-contiguous volumes, the ysize of the pitched pointer needs
-        //  to match the height (in voxels) of the original volume memory.
-        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
-    }
-
-    // Extent width is defined in terms of elements if any cudaArray is present,
-    //  otherwise in number of bytes (for pitched pointer)
-    size_t per_voxel = 1;
-    if (usage() == gpu::Usage_PitchedPointer) {
-        params.srcPtr = pitched_ptr();
-        per_voxel = type_size(vol.voxel_type());
-    }
-    else {
-        params.srcArray = array_ptr();
-        per_voxel = 1;
-    }
-
-    params.extent = make_cudaExtent(_size.x * per_voxel, _size.y, _size.z);
-
+    cudaMemcpy3DParms params = make_download_params(*this, vol);
     CUDA_CHECK_ERRORS(cudaMemcpy3D(&params));
 
     vol.set_origin(_origin);
@@ -432,36 +518,7 @@ void GpuVolume::download(Volume& vol, const cuda::Stream& stream) const
     ASSERT(valid()); // Requires gpu memory to be allocated
     ASSERT(vol.valid()); // Requires cpu memory to be allocated as well
 
-    // We also assume both volumes have same dimensions
-    ASSERT(vol.size() == _size);
-    ASSERT(vol.voxel_type() == voxel_type());
-
-    cudaMemcpy3DParms params = {0};
-    params.kind = cudaMemcpyDeviceToHost;
-    if (vol.is_contiguous()) {
-        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, _size.y);
-    } else {
-        // For non-contiguous volumes, the ysize of the pitched pointer needs
-        //  to match the height (in voxels) of the original volume memory.
-        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
-    }
-
-    // Extent width is defined in terms of elements if any cudaArray is present,
-    //  otherwise in number of bytes (for pitched pointer)
-    size_t per_voxel = 1;
-    if (usage() == gpu::Usage_PitchedPointer) {
-        params.srcPtr = pitched_ptr();
-        per_voxel = type_size(vol.voxel_type());
-    }
-    else {
-        params.srcArray = array_ptr();
-        per_voxel = 1;
-    }
-
-    params.extent = make_cudaExtent(_size.x * per_voxel, _size.y, _size.z);
-
+    cudaMemcpy3DParms params = make_download_params(*this, vol);
     CUDA_CHECK_ERRORS(cudaMemcpy3DAsync(&params, stream));
 
     vol.set_origin(_origin);
@@ -472,35 +529,7 @@ void GpuVolume::upload(const Volume& vol)
     ASSERT(valid()); // Requires gpu memory to be allocated
     ASSERT(vol.valid()); // Requires cpu memory to be allocated as well
 
-    // We also assume both volumes have same dimensions
-    ASSERT(vol.size() == _size);
-    ASSERT(vol.voxel_type() == voxel_type());
-
-    cudaMemcpy3DParms params = {0};
-    params.kind = cudaMemcpyHostToDevice;
-    if (vol.is_contiguous()) {
-        params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, _size.y);
-    } else {
-        // For non-contiguous volumes, the ysize of the pitched pointer needs
-        //  to match the height (in voxels) of the original volume memory.
-        params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
-    }
-
-    // Extent width is defined in terms of elements if any cudaArray is present,
-    //  otherwise in number of bytes (for pitched pointer)
-    size_t per_voxel = 1;
-    if (usage() == gpu::Usage_PitchedPointer) {
-        params.dstPtr = pitched_ptr();
-        per_voxel = type_size(vol.voxel_type());
-    }
-    else {
-        params.dstArray = array_ptr();
-        per_voxel = 1;
-    }
-    params.extent = make_cudaExtent(_size.x * per_voxel, _size.y, _size.z);
-    
+    cudaMemcpy3DParms params = make_upload_params(vol, *this);
     CUDA_CHECK_ERRORS(cudaMemcpy3D(&params));
 
     set_origin(vol.origin());
@@ -515,24 +544,7 @@ void GpuVolume::upload(const Volume& vol, const cuda::Stream& stream)
     ASSERT(vol.size() == _size);
     ASSERT(vol.voxel_type() == voxel_type());
 
-    cudaMemcpy3DParms params = {0};
-    params.kind = cudaMemcpyHostToDevice;
-    params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-        vol.strides()[1], _size.x, _size.y);
-
-    // Extent width is defined in terms of elements if any cudaArray is present,
-    //  otherwise in number of bytes (for pitched pointer)
-    size_t per_voxel = 1;
-    if (usage() == gpu::Usage_PitchedPointer) {
-        params.dstPtr = pitched_ptr();
-        per_voxel = type_size(vol.voxel_type());
-    }
-    else {
-        params.dstArray = array_ptr();
-        per_voxel = 1;
-    }
-    params.extent = make_cudaExtent(_size.x * per_voxel, _size.y, _size.z);
-    
+    cudaMemcpy3DParms params = make_upload_params(vol, *this);
     CUDA_CHECK_ERRORS(cudaMemcpy3DAsync(&params, stream));
 
     set_origin(vol.origin());
@@ -566,12 +578,18 @@ cudaPitchedPtr GpuVolume::pitched_ptr() const
     ASSERT(valid());
     ASSERT(_data);
     ASSERT(usage() == gpu::Usage_PitchedPointer);
-    return _data->pitched_ptr;
+    return _ptr;
+}
+GpuVolume GpuVolume::operator()(const Range& x, const Range& y, const Range& z)
+{
+    return GpuVolume(*this, x, y, z);
 }
 void GpuVolume::allocate(const dim3& size, Type voxel_type, gpu::Usage usage)
 {
     _size = size;
     _data = allocate_gpu_volume(size, voxel_type, usage);
+    if (usage == gpu::Usage_PitchedPointer) 
+        _ptr = _data->pitched_ptr;
 }
 } // namespace stk
 

--- a/src/stk/image/gpu_volume.cpp
+++ b/src/stk/image/gpu_volume.cpp
@@ -398,8 +398,15 @@ void GpuVolume::download(Volume& vol) const
 
     cudaMemcpy3DParms params = {0};
     params.kind = cudaMemcpyDeviceToHost;
-    params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-        _size.x * type_size(vol.voxel_type()), _size.x, _size.y);
+    if (vol.is_contiguous()) {
+        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, _size.y);
+    } else {
+        // For non-contiguous volumes, the ysize of the pitched pointer needs
+        //  to match the height (in voxels) of the original volume memory.
+        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
+    }
 
     // Extent width is defined in terms of elements if any cudaArray is present,
     //  otherwise in number of bytes (for pitched pointer)
@@ -431,8 +438,15 @@ void GpuVolume::download(Volume& vol, const cuda::Stream& stream) const
 
     cudaMemcpy3DParms params = {0};
     params.kind = cudaMemcpyDeviceToHost;
-    params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-        _size.x * type_size(vol.voxel_type()), _size.x, _size.y);
+    if (vol.is_contiguous()) {
+        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, _size.y);
+    } else {
+        // For non-contiguous volumes, the ysize of the pitched pointer needs
+        //  to match the height (in voxels) of the original volume memory.
+        params.dstPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
+    }
 
     // Extent width is defined in terms of elements if any cudaArray is present,
     //  otherwise in number of bytes (for pitched pointer)
@@ -464,8 +478,15 @@ void GpuVolume::upload(const Volume& vol)
 
     cudaMemcpy3DParms params = {0};
     params.kind = cudaMemcpyHostToDevice;
-    params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-        _size.x * type_size(vol.voxel_type()), _size.x, _size.y);
+    if (vol.is_contiguous()) {
+        params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, _size.y);
+    } else {
+        // For non-contiguous volumes, the ysize of the pitched pointer needs
+        //  to match the height (in voxels) of the original volume memory.
+        params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
+            vol.strides()[1], _size.x, vol.strides()[1]/vol.strides()[0]);
+    }
 
     // Extent width is defined in terms of elements if any cudaArray is present,
     //  otherwise in number of bytes (for pitched pointer)
@@ -497,7 +518,7 @@ void GpuVolume::upload(const Volume& vol, const cuda::Stream& stream)
     cudaMemcpy3DParms params = {0};
     params.kind = cudaMemcpyHostToDevice;
     params.srcPtr = make_cudaPitchedPtr(const_cast<void*>(vol.ptr()),
-        _size.x * type_size(vol.voxel_type()), _size.x, _size.y);
+        vol.strides()[1], _size.x, _size.y);
 
     // Extent width is defined in terms of elements if any cudaArray is present,
     //  otherwise in number of bytes (for pitched pointer)

--- a/src/stk/image/gpu_volume.h
+++ b/src/stk/image/gpu_volume.h
@@ -12,6 +12,7 @@
 namespace stk
 {
     class Volume;
+    struct Range;
 
     namespace cuda
     {
@@ -43,6 +44,12 @@ namespace stk
     {
     public:
         GpuVolume();
+        
+        // @remark This does not copy the data, use clone if you want a separate copy.
+        GpuVolume(const GpuVolume& other);
+        // @remark This does not copy the data, use clone if you want a separate copy.
+        GpuVolume& operator=(const GpuVolume& other);
+
         // The usage parameter specified whether this volume should be accessed
         //  as a pitched pointer, i.e.
         //      void kernel(ptr) { x = ptr[0]; }
@@ -50,6 +57,12 @@ namespace stk
         //      void kernel(ptr) { x = tex3D(vol, px, py, pz); }
         GpuVolume(const dim3& size, Type voxel_type, 
             gpu::Usage usage = gpu::Usage_PitchedPointer);
+        
+        // Creates a new reference to a region within an existing volume
+        // There's a chance that the resulting volume does not contain contiguous memory when
+        //  created using this constructor. Use ptr() with caution and see `is_contiguous`.
+        // @remark This does not copy the data, use clone if you want a separate copy.
+        GpuVolume(const GpuVolume& other, const Range& x, const Range& y, const Range& z);
         ~GpuVolume();
         
         // Allocates volume memory for a volume with specified parameters
@@ -167,12 +180,20 @@ namespace stk
         // Only valid when usage is set to pitched pointer
         cudaPitchedPtr pitched_ptr() const;
 
+        // Creates a new reference to a region within an existing volume
+        // There's a chance that the resulting volume does not contain contiguous memory when
+        //  created using this constructor.
+        // @remark This does not copy the data, use clone if you want a separate copy.
+        GpuVolume operator()(const Range& x, const Range& y, const Range& z);
+
     private:
         std::shared_ptr<GpuVolumeData> _data;
 
         dim3 _size;
         float3 _origin;
         float3 _spacing;
+
+        cudaPitchedPtr _ptr; // For pitched pointer usage only
     };
 
     namespace gpu

--- a/src/stk/image/volume.cpp
+++ b/src/stk/image/volume.cpp
@@ -158,11 +158,11 @@ void Volume::copy_from(const Volume& other)
     else {
         size_t row_bytes = _strides[1];
 
-        for (int z = 0; z < _size.z; ++z) {
+        for (int z = 0; z < (int)_size.z; ++z) {
             uint8_t* dst_row = reinterpret_cast<uint8_t*>(_ptr) + z * _strides[2];
             uint8_t* src_row = reinterpret_cast<uint8_t*>(other._ptr) + z * other._strides[2];
 
-            for (int y = 0; y < _size.y; ++y) {
+            for (int y = 0; y < (int)_size.y; ++y) {
                 memcpy(dst_row, src_row, row_bytes);
 
                 dst_row += _strides[1];
@@ -179,7 +179,7 @@ Volume Volume::as_type(Type type) const
     ASSERT(valid());
     ASSERT(type != Type_Unknown);
     // Non-contiguous not supported for now, this function is gonna be refactored anyway
-    ASSERT(is_contiguous() && other.is_contiguous());
+    ASSERT(is_contiguous());
     if (_voxel_type == type)
         return *this;
 

--- a/src/stk/image/volume.cpp
+++ b/src/stk/image/volume.cpp
@@ -147,7 +147,7 @@ void Volume::copy_from(const Volume& other)
         memcpy(_ptr, other._ptr, num_bytes);
     }
     else {
-        size_t row_bytes = _strides[1];
+        size_t row_bytes = type_size(voxel_type()) * _size.x;
 
         for (int z = 0; z < (int)_size.z; ++z) {
             uint8_t* dst_row = reinterpret_cast<uint8_t*>(_ptr) + z * _strides[2];

--- a/src/stk/image/volume.cpp
+++ b/src/stk/image/volume.cpp
@@ -115,21 +115,12 @@ Volume::Volume(const Volume& other, const Range& x, const Range& y, const Range&
     int ny = y.end - y.begin;
     int nz = z.end - z.begin;
 
-    uint8_t* ptr = reinterpret_cast<uint8_t*>(_ptr);
+    uint8_t* ptr = reinterpret_cast<uint8_t*>(_ptr)
+        + x.begin * _strides[0] + y.begin * _strides[1] + z.begin * _strides[2];
     
-    _contiguous = true;
-    if (z.begin != 0 && z.end != (int)_size.z) {
         // any offset in z axis does not break contiguity 
-        ptr += z.begin * _strides[2];
-    }
-
-    if (y.begin != 0 && y.end != (int)_size.y) {
-        ptr += y.begin * _strides[1];
-        _contiguous = false;
-    }
-
-    if (x.begin != 0 && x.end != (int)_size.x) {
-        ptr += x.begin * _strides[0];
+    _contiguous = true;
+    if (nx != (int)other._size.x || ny != (int)other._size.y) {
         _contiguous = false;
     }
 

--- a/src/stk/image/volume.cpp
+++ b/src/stk/image/volume.cpp
@@ -236,6 +236,10 @@ const float3& Volume::spacing() const
 {
     return _spacing;
 }
+const size_t* Volume::strides() const
+{
+    return _strides;
+}
 void Volume::copy_meta_from(const Volume& other)
 {
     _origin = other._origin;

--- a/src/stk/image/volume.cpp
+++ b/src/stk/image/volume.cpp
@@ -129,7 +129,7 @@ Volume::Volume(const Volume& other, const Range& x, const Range& y, const Range&
     }
 
     if (x.begin != 0 && x.end != (int)_size.x) {
-        ptr += y.begin * _strides[0];
+        ptr += x.begin * _strides[0];
         _contiguous = false;
     }
 

--- a/src/stk/image/volume.h
+++ b/src/stk/image/volume.h
@@ -153,6 +153,7 @@ namespace stk
 
         // @remark This does not copy the data, use clone if you want a separate copy.
         Volume(const Volume& other);
+        // @remark This does not copy the data, use clone if you want a separate copy.
         Volume& operator=(const Volume& other);
 
     protected:

--- a/src/stk/image/volume.h
+++ b/src/stk/image/volume.h
@@ -134,6 +134,9 @@ namespace stk
         const float3& origin() const;
         const float3& spacing() const;
 
+        // Strides for x, y, z
+        const size_t* strides() const;
+
         // Copies meta data (origin, spacing, ...) from the provided volume.
         void copy_meta_from(const Volume& other);
 

--- a/src/stk/image/volume.inl
+++ b/src/stk/image/volume.inl
@@ -26,6 +26,14 @@ VolumeHelper<T>::VolumeHelper(const dim3& size, T* value) :
 {
 }
 template<typename T>
+VolumeHelper<T>::VolumeHelper(
+    const VolumeHelper<T>& other, 
+    const Range& x,
+    const Range& y,
+    const Range& z) : Volume(other, x, y, z)
+{
+}
+template<typename T>
 VolumeHelper<T>::~VolumeHelper()
 {
 }
@@ -39,7 +47,8 @@ void VolumeHelper<T>::fill(const T& value)
 {
     for (uint32_t z = 0; z < _size.z; ++z) {
         for (uint32_t y = 0; y < _size.y; ++y) {
-            T* begin = (T*)(((uint8_t*)_ptr) + (z * _stride * _size.y + y * _stride));
+            // x axis should always be contiguous
+            T* begin = (T*)(((uint8_t*)_ptr) + (z * _strides[2] + y * _strides[1]));
             T* end = begin + _size.x;
             std::fill(begin, end, value);
         }
@@ -337,12 +346,17 @@ T& VolumeHelper<T>::operator()(const int3& p)
     return operator()(p.x, p.y, p.z);
 }
 template<typename T>
+VolumeHelper<T> VolumeHelper<T>::operator()(const Range& x, const Range& y, const Range& z)
+{
+    return Volume::operator()(x,y,z);
+}
+template<typename T>
 inline size_t VolumeHelper<T>::offset(int x, int y, int z) const
 {
     DASSERT(x < int(_size.x));
     DASSERT(y < int(_size.y));
     DASSERT(z < int(_size.z));
-    return z * _stride * _size.y + y * _stride + x * sizeof(T);
+    return z * _strides[2] + y * _strides[1] + x * _strides[0];
 }
 
 template<typename T>

--- a/test/test_cuda_kernel.cu
+++ b/test/test_cuda_kernel.cu
@@ -48,8 +48,6 @@ __global__ void copy_texture_kernel(cudaTextureObject_t in, cudaSurfaceObject_t 
 
 TEST_CASE("cuda_copy_kernel", "[cuda]")
 {
-    cuda::init();
-
     #define TEST_TYPE(T) \
         SECTION(#T) { \
             T* test_data = new T[W*H*D]; \
@@ -106,8 +104,6 @@ TEST_CASE("cuda_copy_kernel", "[cuda]")
 
 TEST_CASE("cuda_copy_texture_kernel", "[cuda]")
 {
-    cuda::init();
-    
     #define TEST_TYPE(T) \
         SECTION(#T) { \
             T* test_data = new T[W*H*D]; \

--- a/test/test_cuda_linear_at.cu
+++ b/test/test_cuda_linear_at.cu
@@ -27,8 +27,6 @@ __global__ void linear_at_border_kernel(cuda::VolumePtr<T> in, cuda::VolumePtr<T
 
 TEST_CASE("cuda_linear_at", "[cuda]")
 {
-    cuda::init();
-
     dim3 dims{2,2,2};
     
     VolumeFloat in(dims, 1.0f);

--- a/test/test_volume.cpp
+++ b/test/test_volume.cpp
@@ -713,12 +713,6 @@ TEST_CASE("volume_region", "[volume]")
     SECTION("constructor") {
         VolumeInt vol({4, 4, 4}, val);
         
-        // Should be:
-        // 22, 23
-        // 26, 27
-        //
-        // 38, 39
-        // 42, 43
         VolumeInt sub(vol, {1,4}, {1,4}, {1, 4});
         REQUIRE(sub.size().x == 3);
         REQUIRE(sub.size().y == 3);
@@ -764,29 +758,6 @@ TEST_CASE("volume_region", "[volume]")
         REQUIRE(sub3(0,2,2) == 41);
         REQUIRE(sub3(1,2,2) == 42);
         REQUIRE(sub3(2,2,2) == 43);
-    }
-    SECTION("operator") {
-        VolumeInt vol({4, 4, 4}, val);
-        
-        // Should be:
-        // 22, 23
-        // 26, 27
-        //
-        // 38, 39
-        // 42, 43
-        VolumeInt sub = vol({1,3}, {1,3}, {1, 3});
-        REQUIRE(sub.size().x == 2);
-        REQUIRE(sub.size().y == 2);
-        REQUIRE(sub.size().z == 2);
-        
-        REQUIRE(sub(0,0,0) == 22);
-        REQUIRE(sub(1,0,0) == 23);
-        REQUIRE(sub(0,1,0) == 26);
-        REQUIRE(sub(1,1,0) == 27);
-        REQUIRE(sub(0,0,1) == 38);
-        REQUIRE(sub(1,0,1) == 39);
-        REQUIRE(sub(0,1,1) == 42);
-        REQUIRE(sub(1,1,1) == 43);
     }
     SECTION("copy_from") {
         // SubVol -> SubVol
@@ -848,5 +819,31 @@ TEST_CASE("volume_region", "[volume]")
             }
         }
     }
-    
+    SECTION("referencing") {
+        // Just to check that they actually reference the same memory
+
+        VolumeInt vol({4, 4, 4}, val);
+        VolumeInt subvol(vol, {0,2}, {0, 2}, {0, 2});
+
+        for (int z = 0; z < 2; ++z) {
+        for (int y = 0; y < 2; ++y) {
+        for (int x = 0; x < 2; ++x) {
+            subvol(x,y,z) = -1;
+        }
+        }
+        }
+
+        for (int z = 0; z < 4; ++z) {
+        for (int y = 0; y < 4; ++y) {
+        for (int x = 0; x < 4; ++x) {
+            if (x < 2 && y < 2 && z < 2) {
+                REQUIRE(vol(x,y,z) == -1);
+            }
+            else {
+                REQUIRE(vol(x,y,z) != -1);
+            }
+        }
+        }
+        }
+    }
 }

--- a/test/test_volume.cpp
+++ b/test/test_volume.cpp
@@ -686,3 +686,70 @@ TEST_CASE("find_min_max", "[volume]")
         REQUIRE(max == Approx(8));
     }
 }
+TEST_CASE("volume_region", "[volume]")
+{
+    int val[] = {
+         1,  2,  3,  4,
+         5,  6,  7,  8,
+         9, 10, 11, 12,
+        13, 14, 15, 16,
+
+        17, 18, 19, 20,
+        21, 22, 23, 24,
+        25, 26, 27, 28,
+        29, 30, 31, 32,
+
+        33, 34, 35, 36,
+        37, 38, 39, 40,
+        41, 42, 43, 44,
+        45, 46, 47, 48
+    };
+    
+    SECTION("constructor") {
+        VolumeInt vol({4, 4, 3}, val);
+        
+        // Should be:
+        // 22, 23
+        // 26, 27
+        //
+        // 38, 39
+        // 42, 43
+        VolumeInt sub(vol, {1,3}, {1,3}, {1, 3});
+        REQUIRE(sub.size().x == 2);
+        REQUIRE(sub.size().y == 2);
+        REQUIRE(sub.size().z == 2);
+        REQUIRE(sub.is_contiguous() == false);
+        
+        REQUIRE(sub(0,0,0) == 22);
+        REQUIRE(sub(1,0,0) == 23);
+        REQUIRE(sub(0,1,0) == 26);
+        REQUIRE(sub(1,1,0) == 27);
+        REQUIRE(sub(0,0,1) == 38);
+        REQUIRE(sub(1,0,1) == 39);
+        REQUIRE(sub(0,1,1) == 42);
+        REQUIRE(sub(1,1,1) == 43);
+    }
+    SECTION("operator") {
+        VolumeInt vol({4, 4, 3}, val);
+        
+        // Should be:
+        // 22, 23
+        // 26, 27
+        //
+        // 38, 39
+        // 42, 43
+        VolumeInt sub = vol({1,3}, {1,3}, {1, 3});
+        REQUIRE(sub.size().x == 2);
+        REQUIRE(sub.size().y == 2);
+        REQUIRE(sub.size().z == 2);
+        
+        REQUIRE(sub(0,0,0) == 22);
+        REQUIRE(sub(1,0,0) == 23);
+        REQUIRE(sub(0,1,0) == 26);
+        REQUIRE(sub(1,1,0) == 27);
+        REQUIRE(sub(0,0,1) == 38);
+        REQUIRE(sub(1,0,1) == 39);
+        REQUIRE(sub(0,1,1) == 42);
+        REQUIRE(sub(1,1,1) == 43);
+    }
+}

--- a/test/test_volume.cpp
+++ b/test/test_volume.cpp
@@ -702,11 +702,16 @@ TEST_CASE("volume_region", "[volume]")
         33, 34, 35, 36,
         37, 38, 39, 40,
         41, 42, 43, 44,
-        45, 46, 47, 48
+        45, 46, 47, 48,
+
+        49, 50, 51, 52,
+        53, 54, 55, 56,
+        57, 58, 59, 60,
+        61, 62, 63, 64
     };
     
     SECTION("constructor") {
-        VolumeInt vol({4, 4, 3}, val);
+        VolumeInt vol({4, 4, 4}, val);
         
         // Should be:
         // 22, 23
@@ -714,10 +719,10 @@ TEST_CASE("volume_region", "[volume]")
         //
         // 38, 39
         // 42, 43
-        VolumeInt sub(vol, {1,3}, {1,3}, {1, 3});
-        REQUIRE(sub.size().x == 2);
-        REQUIRE(sub.size().y == 2);
-        REQUIRE(sub.size().z == 2);
+        VolumeInt sub(vol, {1,4}, {1,4}, {1, 4});
+        REQUIRE(sub.size().x == 3);
+        REQUIRE(sub.size().y == 3);
+        REQUIRE(sub.size().z == 3);
         REQUIRE(sub.is_contiguous() == false);
         
         REQUIRE(sub(0,0,0) == 22);
@@ -728,9 +733,40 @@ TEST_CASE("volume_region", "[volume]")
         REQUIRE(sub(1,0,1) == 39);
         REQUIRE(sub(0,1,1) == 42);
         REQUIRE(sub(1,1,1) == 43);
+
+        VolumeInt sub2(sub, {1,2}, {1,2}, {0,2});
+        REQUIRE(sub2.size().x == 1);
+        REQUIRE(sub2.size().y == 1);
+        REQUIRE(sub2.size().z == 2);
+        REQUIRE(sub2.is_contiguous() == false);
+
+        REQUIRE(sub2(0,0,0) == 27);
+        REQUIRE(sub2(0,0,1) == 43);
+
+        VolumeInt sub3(vol, {0,3}, {0,3}, {0,3});
+        REQUIRE(sub3.size().x == 3);
+        REQUIRE(sub3.size().y == 3);
+        REQUIRE(sub3.size().z == 3);
+        REQUIRE(sub3.is_contiguous() == false);
+
+        REQUIRE(sub3(0,0,0) == 1);
+        REQUIRE(sub3(1,0,0) == 2);
+        REQUIRE(sub3(2,0,0) == 3);
+        
+        REQUIRE(sub3(0,2,0) == 9);
+        REQUIRE(sub3(1,2,0) == 10);
+        REQUIRE(sub3(2,2,0) == 11);
+
+        REQUIRE(sub3(0,0,2) == 33);
+        REQUIRE(sub3(1,0,2) == 34);
+        REQUIRE(sub3(2,0,2) == 35);
+        
+        REQUIRE(sub3(0,2,2) == 41);
+        REQUIRE(sub3(1,2,2) == 42);
+        REQUIRE(sub3(2,2,2) == 43);
     }
     SECTION("operator") {
-        VolumeInt vol({4, 4, 3}, val);
+        VolumeInt vol({4, 4, 4}, val);
         
         // Should be:
         // 22, 23
@@ -752,4 +788,65 @@ TEST_CASE("volume_region", "[volume]")
         REQUIRE(sub(0,1,1) == 42);
         REQUIRE(sub(1,1,1) == 43);
     }
+    SECTION("copy_from") {
+        // SubVol -> SubVol
+        {
+            VolumeInt vol({4, 4, 4}, val);
+            VolumeInt dst = vol({2,4}, {2,4}, {2,4});
+            VolumeInt src = vol({0,2}, {0,2}, {0,2});
+            dst.copy_from(src);
+
+            for (int z = 0; z < (int)dst.size().z; ++z) {
+            for (int y = 0; y < (int)dst.size().y; ++y) {
+            for (int x = 0; x < (int)dst.size().x; ++x) {
+                REQUIRE(dst(x,y,z) == src(x,y,z));
+            }
+            }
+            }
+        }
+
+        // SubVol -> Vol
+        {
+            VolumeInt vol({4, 4, 4}, val);
+            VolumeInt dst = VolumeInt({2,2,2});
+            VolumeInt src = vol({0,2}, {0,2}, {0,2});
+
+            dst.copy_from(src);
+
+            for (int z = 0; z < (int)dst.size().z; ++z) {
+            for (int y = 0; y < (int)dst.size().y; ++y) {
+            for (int x = 0; x < (int)dst.size().x; ++x) {
+                REQUIRE(dst(x,y,z) == src(x,y,z));
+            }
+            }
+            }
+        }
+
+        // Vol -> SubVol
+        {
+            VolumeInt vol({4, 4, 4}, val);
+
+            int sub_val[] = {
+                1, 2,
+                3, 4,
+
+                5, 6,
+                7, 8
+            };
+
+            VolumeInt dst = vol({1,3}, {1,3}, {1,3});
+            VolumeInt src = VolumeInt({2,2,2}, sub_val);
+
+            dst.copy_from(src);
+
+            for (int z = 0; z < (int)dst.size().z; ++z) {
+            for (int y = 0; y < (int)dst.size().y; ++y) {
+            for (int x = 0; x < (int)dst.size().x; ++x) {
+                REQUIRE(dst(x,y,z) == src(x,y,z));
+            }
+            }
+            }
+        }
+    }
+    
 }


### PR DESCRIPTION
I kinda like this concept of subvolumes that references the same memory. They are really neat for subdividing problems. Therefore I started implementing this for the STK Volume class. These changes affects the behaviour in a few cases so I think they'll need a proper review.

For `Volume`, the largest difference is the fact that memory within the volume is no longer guaranteed to be contiguous (see `is_contiguous()`). So any direct use of the raw pointer (`ptr()`) should probably be avoided. Regular access through `VolumeHelper<T>` should be fine though.

In short: For `Volume`, a subvolume keeps a reference to the backing data and a pointer to the origin (0,0,0) in its region. The size kept in the subvolume is the size of the subregion. For data access the strides in all axes are kept for the backing data.

I also wanted this to play nice with `GpuVolume` so the same tools for creating subvolumes are available there as well. This should provide cool support for uploading/downloading partial volumes for instance. The regular use of `GpuVolume` should not be affected that much since pitched pointers basically work this way already (Subvolumes with textures are not supported and probably never will be).

See test cases `volume_region` and `gpu_volume_region` for use cases. I have probably missed a lot of cases in the tests so I'll be extending them shortly.