### PR TITLE
remove deprecated FindCUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,11 @@ endif()
 
 if (STK_USE_CUDA)
     add_definitions(-DSTK_USE_CUDA)
-    find_package(CUDA REQUIRED)
+    enable_language(CUDA)
+
+    if (STK_ENABLE_FAST_MATH)
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
+    endif()
 endif()
 
 if (STK_LOGGING_PREFIX_FILE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,26 +44,24 @@ if (STK_USE_CUDA)
     )
 endif()
 
-if (STK_USE_CUDA)
-    cuda_add_library(stk STATIC ${STK_SRCS})
-else()
-    add_library(stk STATIC ${STK_SRCS})
-endif()
+add_library(stk STATIC ${STK_SRCS})
 
-target_include_directories(stk PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CUDA_INCLUDE_DIRS})
-target_link_libraries(stk ${CUDA_CUDA_LIBRARY} ${CUDA_CUDART_LIBRARY})
+target_include_directories(stk PUBLIC 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+    )
 
 if(NIFTI_FOUND)
     target_include_directories(stk PUBLIC ${NIFTI_INCLUDE_DIR})
-    target_link_libraries(stk ${NIFTI_LIBRARIES})
+    target_link_libraries(stk PUBLIC ${NIFTI_LIBRARIES})
 else()
-    target_link_libraries(stk niftiio)
+    target_link_libraries(stk PUBLIC niftiio)
 endif()
 
 if(NrrdIO_FOUND)
     target_include_directories(stk PUBLIC ${NrrdIO_INCLUDE_DIR})
-    target_link_libraries(stk ${NrrdIO_LIBRARIES})
+    target_link_libraries(stk PUBLIC ${NrrdIO_LIBRARIES})
 else()
-    target_link_libraries(stk NrrdIO)
+    target_link_libraries(stk PUBLIC NrrdIO)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,11 +23,7 @@ if (STK_USE_CUDA)
     )
 endif ()
 
-if (STK_USE_CUDA)
-    cuda_add_executable(stk_test ${STK_TEST_SRCS})
-else ()
-    add_executable(stk_test ${STK_TEST_SRCS})
-endif ()
+add_executable(stk_test ${STK_TEST_SRCS})
 
 add_test(stk_test stk_test)
 


### PR DESCRIPTION
FindCUDA was starting to give some troubles on one of my setups after updating to CMake 3.12. This should solve the issue, hopefully, and as a side effect it cleans the CMake files a bit.