### PR TITLE
Lazily evaluated logging

### DIFF
--- a/src/stk/common/log.cpp
+++ b/src/stk/common/log.cpp
@@ -237,7 +237,7 @@ namespace stk
     {
     #ifdef STK_LOGGING_PREFIX_LEVEL
         const char* level_to_str[Num_LogLevel] = {
-            "DBG",
+            "VER",
             "INF",
             "WAR",
             "ERR",
@@ -369,7 +369,7 @@ namespace stk
     LogLevel log_level()
     {
         if (!_logger_data) {
-            return LogLevel::Num_LogLevel;
+            return LogLevel::Info;
         }
         return std::accumulate(
                 _logger_data->sinks.begin(),
@@ -380,8 +380,8 @@ namespace stk
     }
     LogLevel log_level_from_str(const std::string& s)
     {
-        if (s == "Debug") {
-            return LogLevel::Debug;
+        if (s == "Verbose") {
+            return LogLevel::Verbose;
         }
         else if (s == "Info") {
             return LogLevel::Info;
@@ -395,12 +395,12 @@ namespace stk
         else if (s == "Fatal") {
             return LogLevel::Fatal;
         }
-        return LogLevel::Info;
+        throw std::runtime_error(("Unrecognised log level '" + s + "'").c_str());
     }
     LogLevel log_level_from_str(const char * const s)
     {
         if (!s) {
-            return LogLevel::Info;
+            throw std::runtime_error("Invalid log level");
         }
         return log_level_from_str(std::string(s));
     }

--- a/src/stk/common/log.h
+++ b/src/stk/common/log.h
@@ -49,6 +49,7 @@ namespace stk
 {
     enum LogLevel
     {
+        Debug,
         Info,
         Warning,
         Error,
@@ -100,6 +101,9 @@ namespace stk
     // Shuts the logging system down.
     void log_shutdown();
 
+    // Get the minimum level among the registered sinks
+    LogLevel log_level();
+
     // Creates a new log file and outputs all messages above the specified level
     void log_add_file(const char* file, LogLevel level);
 
@@ -117,6 +121,11 @@ namespace stk
 
     // Stops the output to the given stream, assuming the stream was added with log_add_stream
     void log_remove_stream(std::ostream * const os);
+
+    // Convert a string to a log level
+    // If the input is unrecognised, the default value LogLevel::Info is returned
+    LogLevel log_level_from_str(const std::string& s);
+    LogLevel log_level_from_str(const char * const s);
 }
 
 template<typename T>
@@ -139,3 +148,8 @@ stk::LogMessage& operator<<(stk::LogMessage& s, const T& v)
 #endif
 
 #define LOG_IF(level, expr) !(expr) ? (void)0 : LOG(level)
+
+// Evaluate the expression to be logged lazily, only if there is at least
+// one sink that will consume it.
+#define LOG_LAZY(level, expr) if (stk::level >= stk::log_level()) { LOG(level) << expr; }
+

--- a/src/stk/common/log.h
+++ b/src/stk/common/log.h
@@ -49,7 +49,7 @@ namespace stk
 {
     enum LogLevel
     {
-        Debug,
+        Verbose,
         Info,
         Warning,
         Error,
@@ -136,10 +136,12 @@ stk::LogMessage& operator<<(stk::LogMessage& s, const T& v)
 }
 
 #if STK_LOGGING_PREFIX_FILE
-    #define LOG(level) stk::LogFinisher() & stk::LogMessage(stk::level, __FILE__, __LINE__).stream()
+    #define _STK_LOG(level) stk::LogFinisher() & stk::LogMessage(stk::level, __FILE__, __LINE__).stream()
 #else
-    #define LOG(level) stk::LogFinisher() & stk::LogMessage(stk::level).stream()
+    #define _STK_LOG(level) stk::LogFinisher() & stk::LogMessage(stk::level).stream()
 #endif
+
+#define LOG(level) (stk::level < stk::log_level()) ? (void)0 : _STK_LOG(level)
 
 #ifdef NDEBUG
     #define DLOG(level) stk::NullStream()
@@ -148,8 +150,4 @@ stk::LogMessage& operator<<(stk::LogMessage& s, const T& v)
 #endif
 
 #define LOG_IF(level, expr) !(expr) ? (void)0 : LOG(level)
-
-// Evaluate the expression to be logged lazily, only if there is at least
-// one sink that will consume it.
-#define LOG_LAZY(level, expr) if (stk::level >= stk::log_level()) { LOG(level) << expr; }
 


### PR DESCRIPTION
I added a `Debug` level, and a logging macro whose argument is evaluated lazily, only if there is at least one sink registered with the required logging level.