### PR TITLE
Treat std::cerr as a regular sink

### DIFF
--- a/src/stk/common/log.cpp
+++ b/src/stk/common/log.cpp
@@ -181,10 +181,6 @@ namespace
 
     void log_write(stk::LogLevel level, const char* msg)
     {
-        if (nullptr == _logger_data || !_logger_data->silent) {
-            std::cerr << msg;
-        }
-
         if (_logger_data) {
             for (auto& s : _logger_data->sinks) {
                 s->write(level, msg);
@@ -373,8 +369,8 @@ namespace stk
     LogLevel log_level()
     {
         // Default value when no sink is registered
-        if (!_logger_data || _logger_data->sinks.size() == 0) {
-            return LogLevel::Info;
+        if (!_logger_data) {
+            return LogLevel::Num_LogLevel;
         }
         // Minimum value among the registered sinks
         return std::accumulate(

--- a/src/stk/io/io.cpp
+++ b/src/stk/io/io.cpp
@@ -121,7 +121,7 @@ namespace stk
                 return r;
         }
 
-        LOG(Error) << "No reader found for file " << &filename << ", unsupported format?";
+        LOG(Error) << "No reader found for file " << filename << ", unsupported format?";
 
         return VolumeReader();
     }
@@ -160,7 +160,7 @@ namespace stk
         stk::write_itk_image(vol, filename);
 #else // ifdef STK_ITK_BRIDGE
         VolumeWriter w = find_writer(filename);
-        FATAL_IF(!w.write) << "No writer found for file " << &filename;
+        FATAL_IF(!w.write) << "No writer found for file " << filename;
 
         w.write(filename, vol);
 #endif // ifdef STK_ITK_BRIDGE


### PR DESCRIPTION
How about this? I think this makes everything neater, instead of keep adding corner cases on top of corner cases...